### PR TITLE
Add authentication verification middleware

### DIFF
--- a/src/domain/repositories/users.go
+++ b/src/domain/repositories/users.go
@@ -10,4 +10,5 @@ import (
 type UserRepository interface {
 	Create(ctx context.Context, newUser *models.Users) *errors.DomainError
 	FindByEmail(ctx context.Context, email string) (*models.Users, *errors.DomainError)
+	FindByID(ctx context.Context, userID string) (*models.Users, *errors.DomainError)
 }

--- a/src/factory/factory.go
+++ b/src/factory/factory.go
@@ -12,6 +12,7 @@ import (
 
 type Factory interface {
 	InitUserController() *controllers.UserController
+	InitAuthService() services.AuthService
 }
 
 type factory struct {
@@ -29,4 +30,8 @@ func (f factory) InitUserController() *controllers.UserController {
 	userUsecase := usecase.NewUserUsecase(userRepo, authService, txRepo)
 	userPresenter := presenter.NewUserPresenter()
 	return controllers.NewUserController(userUsecase, authService, userPresenter)
+}
+
+func (f factory) InitAuthService() services.AuthService {
+	return services.NewAuthService()
 }

--- a/src/infra/repository/user_impl.go
+++ b/src/infra/repository/user_impl.go
@@ -49,3 +49,21 @@ func (r *UserRepositoryImpl) FindByEmail(ctx context.Context, email string) (*mo
 
 	return &user, nil
 }
+
+// FindByID
+func (r *UserRepositoryImpl) FindByID(ctx context.Context, userID string) (*models.Users, *myerrors.DomainError) {
+	var user models.Users
+	result := r.db.WithContext(ctx).Where("id = ?", userID).First(&user)
+
+	// エラーが発生した場合
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return &user, myerrors.NewDomainError(myerrors.QueryDataNotFoundError, "ユーザーが見つかりません")
+		}
+		// その他のエラー
+		fmt.Println("その他のエラー:", result.Error)
+		return nil, myerrors.NewDomainError(myerrors.QueryError, result.Error.Error())
+	}
+
+	return &user, nil
+}

--- a/src/interfaces/middlewares/auth.go
+++ b/src/interfaces/middlewares/auth.go
@@ -1,1 +1,46 @@
 package middlewares
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	myerrors "w3st/errors"
+	"w3st/interfaces/controllers"
+
+	"github.com/gin-gonic/gin"
+
+	"w3st/interfaces/services"
+)
+
+func JwtAuthMiddleware(authService services.AuthService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// tokenをヘッダーから取得
+		authHeader := c.Request.Header.Get("Authorization")
+		token := strings.TrimPrefix(authHeader, "Bearer ")
+
+		// tokenの存在を確認
+		if token == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authorization header is required"})
+			c.Abort()
+			return
+		}
+
+		//　tokenの検証
+		userID, err := authService.ValidateToken(token)
+		if err != nil {
+			domainErr := &myerrors.DomainError{}
+			if errors.As(err, &domainErr) {
+				err := controllers.ErrorHandle(domainErr)
+				c.JSON(controllers.HttpStatusCodeFromConnectCode(err.Code()), gin.H{"error": err.Error()})
+				c.Abort()
+				return
+			}
+		}
+		// tokenの検証に成功した場合、userIDをコンテキストに保存
+		c.Set("userID", userID)
+
+		// tokenが有効な場合、次のハンドラーに進む
+		c.Next()
+	}
+}

--- a/src/interfaces/services/auth.go
+++ b/src/interfaces/services/auth.go
@@ -69,7 +69,7 @@ func (a *authService) ValidateToken(token string) (string, *errors.DomainError) 
 
 	subStr, ok := claims["sub"].(string)
 	if !ok {
-		return "", errors.NewDomainError(errors.ErrorUnknown, "user_idの型が不正です")
+		return "", errors.NewDomainError(errors.ErrorUnknown, "subの型が不正です")
 	}
 
 	if _, err := uuid.Parse(subStr); err != nil {

--- a/src/interfaces/services/auth.go
+++ b/src/interfaces/services/auth.go
@@ -4,17 +4,16 @@ import (
 	"os"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 
 	"w3st/domain/models"
 	"w3st/errors"
-
-	"github.com/golang-jwt/jwt/v5"
 )
 
 type AuthService interface {
 	GenerateToken(userID uuid.UUID) (models.Token, *errors.DomainError)
-	ValidateToken(token string) (string, error)
+	ValidateToken(token string) (string, *errors.DomainError)
 }
 
 type authService struct {
@@ -22,57 +21,60 @@ type authService struct {
 }
 
 func NewAuthService() AuthService {
+	secret := os.Getenv("SECRET_KEY")
+	if len(secret) < 32 {
+		panic("SECRET_KEY must be at least 32 bytes long")
+	}
 	return &authService{
-		secretKey: os.Getenv("SECRET_KEY"),
+		secretKey: secret,
 	}
 }
 
-// tokenの生成
+// トークンを生成する
 func (a *authService) GenerateToken(userID uuid.UUID) (models.Token, *errors.DomainError) {
 	claims := jwt.MapClaims{
-		"sub": userID,
-		"exp": time.Now().Add(time.Hour * 24).Unix(),
+		"sub": userID.String(),
+		"exp": time.Now().Add(24 * time.Hour).Unix(),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
-	// トークンの署名
 	signedToken, err := token.SignedString([]byte(a.secretKey))
 	if err != nil {
 		return "", errors.NewDomainError(errors.ErrorUnknown, "トークンの生成に失敗しました")
 	}
+
 	return models.Token(signedToken), nil
 }
 
-// tokenの検証
-func (a *authService) ValidateToken(token string) (string, error) {
+// トークンを検証し、userIDを取得する
+func (a *authService) ValidateToken(token string) (string, *errors.DomainError) {
 	parsedToken, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			// 署名方法がHS256でない場合
-			return nil, errors.NewDomainError(errors.ErrorUnknown, "invalid signing method")
+			return nil, errors.NewDomainError(errors.ErrorUnknown, "署名方式が不正です")
 		}
 		return []byte(a.secretKey), nil
 	})
-	// jwt.Parseのエラー処理
 	if err != nil {
-		return "", errors.NewDomainError(errors.ErrorUnknown, "perseTokenが失敗しました")
+		return "", errors.NewDomainError(errors.ErrorUnknown, "トークンのパースに失敗しました")
 	}
 
 	if !parsedToken.Valid {
-		// トークンが無効な場合
-		return "", errors.NewDomainError(errors.ErrorUnknown, "invalid token")
+		return "", errors.NewDomainError(errors.ErrorUnknown, "無効なトークンです")
 	}
 
 	claims, ok := parsedToken.Claims.(jwt.MapClaims)
-	if !ok || claims["user_id"] == nil {
-		// claimsが無効な場合
-		return "", errors.NewDomainError(errors.ErrorUnknown, "invalid claims")
+	if !ok || claims["sub"] == nil {
+		return "", errors.NewDomainError(errors.ErrorUnknown, "claimsの取得に失敗しました")
 	}
 
-	userID, ok := claims["user_id"].(string)
+	subStr, ok := claims["sub"].(string)
 	if !ok {
-		// user_idがstring型でない場合
-		return "", errors.NewDomainError(errors.ErrorUnknown, "invalid user_id")
+		return "", errors.NewDomainError(errors.ErrorUnknown, "user_idの型が不正です")
 	}
 
-	return userID, nil
+	if _, err := uuid.Parse(subStr); err != nil {
+		return "", errors.NewDomainError(errors.ErrorUnknown, "UUIDのパースに失敗しました")
+	}
+
+	return subStr, nil
 }

--- a/src/mock/repositories/mock_user_repository.go
+++ b/src/mock/repositories/mock_user_repository.go
@@ -65,3 +65,18 @@ func (mr *MockUserRepositoryMockRecorder) FindByEmail(ctx, email interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByEmail", reflect.TypeOf((*MockUserRepository)(nil).FindByEmail), ctx, email)
 }
+
+// FindByID mocks base method.
+func (m *MockUserRepository) FindByID(ctx context.Context, userID string) (*models.Users, *errors.DomainError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByID", ctx, userID)
+	ret0, _ := ret[0].(*models.Users)
+	ret1, _ := ret[1].(*errors.DomainError)
+	return ret0, ret1
+}
+
+// FindByID indicates an expected call of FindByID.
+func (mr *MockUserRepositoryMockRecorder) FindByID(ctx, userID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockUserRepository)(nil).FindByID), ctx, userID)
+}

--- a/src/mock/services/mock_auth_service.go
+++ b/src/mock/services/mock_auth_service.go
@@ -53,11 +53,11 @@ func (mr *MockAuthServiceMockRecorder) GenerateToken(userID interface{}) *gomock
 }
 
 // ValidateToken mocks base method.
-func (m *MockAuthService) ValidateToken(token string) (string, error) {
+func (m *MockAuthService) ValidateToken(token string) (string, *errors.DomainError) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateToken", token)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
+	ret1, _ := ret[1].(*errors.DomainError)
 	return ret0, ret1
 }
 

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"w3st/interfaces/middlewares"
+
 	"w3st/factory"
 	"w3st/infra"
 
@@ -44,11 +46,17 @@ func Init() {
 	users := r.Group("/users")
 	userController := f.InitUserController()
 
+	// Auth
+	authService := f.InitAuthService()
+
 	// ユーザー登録
 	users.POST("/signup", userController.Signup)
 
 	// ログイン
 	users.POST("/login", userController.Login)
+
+	// ユーザー情報取得
+	users.GET("/me", middlewares.JwtAuthMiddleware(authService), userController.GetUserInfo)
 
 	// 指定されたポートでサーバーを開始
 	if err := r.Run(fmt.Sprintf(":%s", port)); err != nil {

--- a/src/usecase/user.go
+++ b/src/usecase/user.go
@@ -13,6 +13,7 @@ import (
 type UserUsecase interface {
 	Create(newUser *models.Users, ctx context.Context) (models.Token, error)
 	FindByEmail(email string) (models.Token, error)
+	FindByID(userID string) (*models.Users, error)
 }
 
 type userUsecase struct {
@@ -82,4 +83,12 @@ func (u *userUsecase) FindByEmail(email string) (models.Token, error) {
 		return "", err
 	}
 	return token, nil
+}
+
+func (u *userUsecase) FindByID(userID string) (*models.Users, error) {
+	user, err := u.userRepo.FindByID(context.Background(), userID)
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
 }


### PR DESCRIPTION
ユーザーリポジトリの拡張：
UserRepositoryインターフェースにFindByIDメソッドを追加し、user_impl.goにその実装を行いました。これにより、ユーザーIDをもとにユーザー情報を取得できるようになりました。ユーザーが存在しない場合や、データベースエラーが発生した場合のエラーハンドリングも含まれている。
    - [[1]](https://github.com/nishi240masa/w3st-cms-back/compare/fix-file-structure...add-authentication-verification-middleware)
    - [[2]](https://github.com/nishi240masa/w3st-cms-back/compare/fix-file-structure...add-authentication-verification-middleware)
    モック用のmock_user_repository.goにもFindByIDのサポートを追加し、テストが可能になった。

認証ミドルウェアの追加：
 JWTトークンの検証およびユーザーIDの抽出を行うJwtAuthMiddlewareをauth.goに追加しました。このミドルウェアにより、保護されたエンドポイントへの安全なアクセスが保証した。

ユーザーコントローラーの強化：
  user.goにGetUserInfoメソッドを追加し、認証済みユーザーの情報を取得できるようにしました。このエンドポイントはJWT認証ミドルウェアによって保護した。

認証サービス（AuthService）の改善：
 トークン検証をより堅牢にし、ドメイン固有のエラーを返すようにした。
SECRET_KEY環境変数のバリデーションを強化し、トークン検証時のエラーメッセージも改善した。

ルーターおよびファクトリの更新：
 router.goを更新し、JwtAuthMiddlewareを適用した上で、新たに/users/meエンドポイントを登録した。
AuthServiceを初期化するためのInitAuthServiceメソッドをFactoryインターフェースおよびその実装に追加した。
- [[1]](https://github.com/nishi240masa/w3st-cms-back/compare/fix-file-structure...add-authentication-verification-middleware)
- [[2]](https://github.com/nishi240masa/w3st-cms-back/compare/fix-file-structure...add-authentication-verification-middleware)