### PR TITLE
refactor(collections):userUuidの不要なログを削除

### DIFF
--- a/src/interfaces/controllers/collections.go
+++ b/src/interfaces/controllers/collections.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"errors"
-	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -95,8 +94,6 @@ func (c *CollectionsController) GetCollectionByUserId(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-
-	log.Default().Println("userUuid:", userUuid)
 
 	// コレクションを取得
 	collection, err := c.collectionUsecase.GetCollectionByUserId(userUuid)


### PR DESCRIPTION
未使用のログ機能のクリーンアップ

コードのクリーンアップ:

* ファイルから未使用の `log` インポートを削除しました。(`src/interfaces/controllers/collections.go`)
* `GetCollectionByUserId` メソッドから、不要なデバッグログ出力ステートメント (`log.Default().Println("userUuid:", userUuid)`) を削除しました。(`src/interfaces/controllers/collections.go`)