### PR TITLE
[CPG-11]: 新しいリポジトリインターフェースを追加 - AuditRepository, MediaRepository, Permiss…

### DIFF
--- a/src/domain/repositories/audit.go
+++ b/src/domain/repositories/audit.go
@@ -1,0 +1,16 @@
+package repositories
+
+import (
+	"context"
+
+	"w3st/domain/models"
+	"w3st/errors"
+)
+
+type AuditRepository interface {
+	Create(ctx context.Context, log *models.AuditLog) *errors.DomainError
+	FindByID(ctx context.Context, id string) (*models.AuditLog, *errors.DomainError)
+	FindByUserID(ctx context.Context, userID string) ([]*models.AuditLog, *errors.DomainError)
+	FindByAction(ctx context.Context, action string) ([]*models.AuditLog, *errors.DomainError)
+	FindAll(ctx context.Context) ([]*models.AuditLog, *errors.DomainError)
+}

--- a/src/domain/repositories/media.go
+++ b/src/domain/repositories/media.go
@@ -1,0 +1,16 @@
+package repositories
+
+import (
+	"context"
+
+	"w3st/domain/models"
+	"w3st/errors"
+)
+
+type MediaRepository interface {
+	Create(ctx context.Context, media *models.MediaAsset) *errors.DomainError
+	FindByID(ctx context.Context, id string) (*models.MediaAsset, *errors.DomainError)
+	FindByUserID(ctx context.Context, userID string) ([]*models.MediaAsset, *errors.DomainError)
+	Update(ctx context.Context, media *models.MediaAsset) *errors.DomainError
+	Delete(ctx context.Context, id string) *errors.DomainError
+}

--- a/src/domain/repositories/permissions.go
+++ b/src/domain/repositories/permissions.go
@@ -1,0 +1,16 @@
+package repositories
+
+import (
+	"context"
+
+	"w3st/domain/models"
+	"w3st/errors"
+)
+
+type PermissionRepository interface {
+	Create(ctx context.Context, permission *models.UserPermission) *errors.DomainError
+	FindByID(ctx context.Context, id string) (*models.UserPermission, *errors.DomainError)
+	FindByUserID(ctx context.Context, userID string) ([]*models.UserPermission, *errors.DomainError)
+	FindByUserIDAndResource(ctx context.Context, userID, resource string) ([]*models.UserPermission, *errors.DomainError)
+	Delete(ctx context.Context, id string) *errors.DomainError
+}

--- a/src/domain/repositories/versions.go
+++ b/src/domain/repositories/versions.go
@@ -1,0 +1,16 @@
+package repositories
+
+import (
+	"context"
+
+	"w3st/domain/models"
+	"w3st/errors"
+)
+
+type VersionRepository interface {
+	Create(ctx context.Context, version *models.ContentVersion) *errors.DomainError
+	FindByID(ctx context.Context, id string) (*models.ContentVersion, *errors.DomainError)
+	FindByContentID(ctx context.Context, contentID string) ([]*models.ContentVersion, *errors.DomainError)
+	FindLatestByContentID(ctx context.Context, contentID string) (*models.ContentVersion, *errors.DomainError)
+	Delete(ctx context.Context, id string) *errors.DomainError
+}


### PR DESCRIPTION
概要
ドメイン層がインフラストラクチャ層に依存しないように、データ操作のためのインターフェースを定義しました。これにより、依存性逆転の原則に従い、ドメイン層の抽象化を強化します。

変更内容
新規ファイル作成:
[src/domain/repositories/media.go](vscode-webview://0pcbjv49pd5v4eutmsst9jfl8ud1r09jsul21gsvve3b8vetj489/src/domain/repositories/media.go:1): MediaRepository インターフェース - メディアアセットのCRUD操作（作成、ID検索、ユーザーID検索、更新、削除）
[src/domain/repositories/versions.go](vscode-webview://0pcbjv49pd5v4eutmsst9jfl8ud1r09jsul21gsvve3b8vetj489/src/domain/repositories/versions.go:1): VersionRepository インターフェース - コンテンツバージョンの管理（作成、ID検索、コンテンツID検索、最新バージョン検索、削除）
[src/domain/repositories/permissions.go](vscode-webview://0pcbjv49pd5v4eutmsst9jfl8ud1r09jsul21gsvve3b8vetj489/src/domain/repositories/permissions.go:1): PermissionRepository インターフェース - ユーザーパーミッションの管理（作成、ID検索、ユーザーID検索、ユーザーIDとリソース検索、削除）
[src/domain/repositories/audit.go](vscode-webview://0pcbjv49pd5v4eutmsst9jfl8ud1r09jsul21gsvve3b8vetj489/src/domain/repositories/audit.go:1): AuditRepository インターフェース - 監査ログの記録と検索（作成、ID検索、ユーザーID検索、アクション検索、全件検索）
技術的詳細
各インターフェースは context.Context を使用してリクエストのライフサイクルを管理
エラーハンドリングは w3st/errors.DomainError を使用
既存の UserRepository インターフェースと同様のパターンで設計
依存関係
この変更は課題 #2 に依存しており、ドメインモデルの定義が完了していることを前提としています。

テスト
インフラストラクチャ層の実装（例: PostgreSQLリポジトリ実装）でこれらのインターフェースを実装し、ユニットテストで検証予定です。