### PR TITLE
[CPG-14]: 新しいDTOを追加 - Audit, Media, Permission, Version

### DIFF
--- a/src/dto/audit_dto.go
+++ b/src/dto/audit_dto.go
@@ -12,6 +12,6 @@ type AuditLogResponse struct {
 	UserID    string `json:"user_id"`
 	Action    string `json:"action"`
 	Resource  string `json:"resource"`
-	CreatedAt string `json:"created_at"`
 	Details   string `json:"details"`
+	CreatedAt string `json:"created_at"`
 }

--- a/src/dto/audit_dto.go
+++ b/src/dto/audit_dto.go
@@ -1,0 +1,17 @@
+package dto
+
+type CreateAuditLog struct {
+	UserID   string `json:"user_id" binding:"required,uuid"`
+	Action   string `json:"action" binding:"required,min=1"`
+	Resource string `json:"resource" binding:"required,min=1"`
+	Details  string `json:"details"`
+}
+
+type AuditLogResponse struct {
+	ID        string `json:"id"`
+	UserID    string `json:"user_id"`
+	Action    string `json:"action"`
+	Resource  string `json:"resource"`
+	CreatedAt string `json:"created_at"`
+	Details   string `json:"details"`
+}

--- a/src/dto/media_dto.go
+++ b/src/dto/media_dto.go
@@ -1,0 +1,28 @@
+package dto
+
+type CreateMedia struct {
+	Name   string `json:"name" binding:"required,min=1"`
+	Type   string `json:"type" binding:"required,min=1"`
+	Path   string `json:"path" binding:"required,min=1"`
+	Size   int64  `json:"size" binding:"required,min=1"`
+	UserID string `json:"user_id" binding:"required,uuid"`
+}
+
+type UpdateMedia struct {
+	ID   string `json:"id" binding:"required,uuid"`
+	Name string `json:"name" binding:"omitempty,min=1"`
+	Type string `json:"type" binding:"omitempty,min=1"`
+	Path string `json:"path" binding:"omitempty,min=1"`
+	Size int64  `json:"size" binding:"omitempty,min=1"`
+}
+
+type MediaResponse struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Path      string `json:"path"`
+	Size      int64  `json:"size"`
+	UserID    string `json:"user_id"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}

--- a/src/dto/permissions_dto.go
+++ b/src/dto/permissions_dto.go
@@ -1,0 +1,22 @@
+package dto
+
+type CreatePermission struct {
+	UserID     string `json:"user_id" binding:"required,uuid"`
+	Permission string `json:"permission" binding:"required,min=1"`
+	Resource   string `json:"resource" binding:"required,min=1"`
+}
+
+type UpdatePermission struct {
+	ID         string `json:"id" binding:"required,uuid"`
+	Permission string `json:"permission" binding:"omitempty,min=1"`
+	Resource   string `json:"resource" binding:"omitempty,min=1"`
+}
+
+type PermissionResponse struct {
+	ID         string `json:"id"`
+	UserID     string `json:"user_id"`
+	Permission string `json:"permission"`
+	Resource   string `json:"resource"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
+}

--- a/src/dto/versions_dto.go
+++ b/src/dto/versions_dto.go
@@ -1,0 +1,23 @@
+package dto
+
+type CreateVersion struct {
+	ContentID string `json:"content_id" binding:"required,uuid"`
+	Data      string `json:"data" binding:"required"`
+	UserID    string `json:"user_id" binding:"required,uuid"`
+}
+
+type UpdateVersion struct {
+	ID     string `json:"id" binding:"required,uuid"`
+	Data   string `json:"data" binding:"omitempty"`
+	UserID string `json:"user_id" binding:"omitempty,uuid"`
+}
+
+type VersionResponse struct {
+	ID        string `json:"id"`
+	ContentID string `json:"content_id"`
+	Version   int    `json:"version"`
+	Data      string `json:"data"`
+	UserID    string `json:"user_id"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}


### PR DESCRIPTION
## 関連するチケット

-https://w3st-cms-back.atlassian.net/browse/CPG-14

---

## 概要 (Overview)

各層のデータ転送用オブジェクト (DTO) を作成し、コントローラーとユースケース間でデータをやり取りするための構造体を定義しました。

---

## 変更内容 (Changes)

- [x] **新機能 (New feature)**

具体的な変更内容をリスト形式で記述してください。

- `src/dto/media_dto.go` の新規作成: MediaAsset 関連の CreateMedia, UpdateMedia, MediaResponse 構造体を定義
- `src/dto/versions_dto.go` の新規作成: ContentVersion 関連の CreateVersion, UpdateVersion, VersionResponse 構造体を定義
- `src/dto/permissions_dto.go` の新規作成: UserPermission 関連の CreatePermission, UpdatePermission, PermissionResponse 構造体を定義
- `src/dto/audit_dto.go` の新規作成: AuditLog 関連の CreateAuditLog, AuditLogResponse 構造体を定義

---

## スクリーンショット (Screenshots)

UIの変更がないため、スクリーンショットは不要です。

---

## 特記事項 (Additional Notes)

各DTO構造体にはJSONタグとバリデーションタグを付与し、APIでのデータ検証とシリアライズをサポートしています。UUIDフィールドはstring型として扱い、バリデーションでuuid形式をチェックします。