### PR TITLE
[CPG-16]: 新しいPresenterを追加 - Audit, Media, Permission, Version

### DIFF
--- a/src/presenter/audit.go
+++ b/src/presenter/audit.go
@@ -23,7 +23,7 @@ func (a *auditPresenter) ResponseAuditLog(log *models.AuditLog) *dto.AuditLogRes
 		Action:    log.Action,
 		Resource:  log.Resource,
 		Details:   log.Details,
-		CreatedAt: log.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt: log.CreatedAt.Format(ISO8601Format),
 	}
 }
 

--- a/src/presenter/audit.go
+++ b/src/presenter/audit.go
@@ -1,0 +1,36 @@
+package presenter
+
+import (
+	"w3st/domain/models"
+	"w3st/dto"
+)
+
+type AuditPresenter interface {
+	ResponseAuditLog(log *models.AuditLog) *dto.AuditLogResponse
+	ResponseAuditLogs(logs []*models.AuditLog) []*dto.AuditLogResponse
+}
+
+type auditPresenter struct{}
+
+func NewAuditPresenter() AuditPresenter {
+	return &auditPresenter{}
+}
+
+func (a *auditPresenter) ResponseAuditLog(log *models.AuditLog) *dto.AuditLogResponse {
+	return &dto.AuditLogResponse{
+		ID:        log.ID.String(),
+		UserID:    log.UserID.String(),
+		Action:    log.Action,
+		Resource:  log.Resource,
+		Details:   log.Details,
+		CreatedAt: log.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+func (a *auditPresenter) ResponseAuditLogs(logs []*models.AuditLog) []*dto.AuditLogResponse {
+	responses := make([]*dto.AuditLogResponse, len(logs))
+	for i, log := range logs {
+		responses[i] = a.ResponseAuditLog(log)
+	}
+	return responses
+}

--- a/src/presenter/constants.go
+++ b/src/presenter/constants.go
@@ -1,0 +1,4 @@
+package presenter
+
+// ISO8601Format is the standard ISO 8601 time format used for API responses
+const ISO8601Format = "2006-01-02T15:04:05Z07:00"

--- a/src/presenter/media.go
+++ b/src/presenter/media.go
@@ -24,8 +24,8 @@ func (m *mediaPresenter) ResponseMedia(media *models.MediaAsset) *dto.MediaRespo
 		Path:      media.Path,
 		Size:      media.Size,
 		UserID:    media.UserID.String(),
-		CreatedAt: media.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt: media.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt: media.CreatedAt.Format(ISO8601Format),
+		UpdatedAt: media.UpdatedAt.Format(ISO8601Format),
 	}
 }
 

--- a/src/presenter/media.go
+++ b/src/presenter/media.go
@@ -1,0 +1,38 @@
+package presenter
+
+import (
+	"w3st/domain/models"
+	"w3st/dto"
+)
+
+type MediaPresenter interface {
+	ResponseMedia(media *models.MediaAsset) *dto.MediaResponse
+	ResponseMedias(medias []*models.MediaAsset) []*dto.MediaResponse
+}
+
+type mediaPresenter struct{}
+
+func NewMediaPresenter() MediaPresenter {
+	return &mediaPresenter{}
+}
+
+func (m *mediaPresenter) ResponseMedia(media *models.MediaAsset) *dto.MediaResponse {
+	return &dto.MediaResponse{
+		ID:        media.ID.String(),
+		Name:      media.Name,
+		Type:      media.Type,
+		Path:      media.Path,
+		Size:      media.Size,
+		UserID:    media.UserID.String(),
+		CreatedAt: media.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt: media.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+func (m *mediaPresenter) ResponseMedias(medias []*models.MediaAsset) []*dto.MediaResponse {
+	responses := make([]*dto.MediaResponse, len(medias))
+	for i, media := range medias {
+		responses[i] = m.ResponseMedia(media)
+	}
+	return responses
+}

--- a/src/presenter/permissions.go
+++ b/src/presenter/permissions.go
@@ -1,0 +1,36 @@
+package presenter
+
+import (
+	"w3st/domain/models"
+	"w3st/dto"
+)
+
+type PermissionPresenter interface {
+	ResponsePermission(permission *models.UserPermission) *dto.PermissionResponse
+	ResponsePermissions(permissions []*models.UserPermission) []*dto.PermissionResponse
+}
+
+type permissionPresenter struct{}
+
+func NewPermissionPresenter() PermissionPresenter {
+	return &permissionPresenter{}
+}
+
+func (p *permissionPresenter) ResponsePermission(permission *models.UserPermission) *dto.PermissionResponse {
+	return &dto.PermissionResponse{
+		ID:         permission.ID.String(),
+		UserID:     permission.UserID.String(),
+		Permission: permission.Permission,
+		Resource:   permission.Resource,
+		CreatedAt:  permission.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:  permission.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+func (p *permissionPresenter) ResponsePermissions(permissions []*models.UserPermission) []*dto.PermissionResponse {
+	responses := make([]*dto.PermissionResponse, len(permissions))
+	for i, permission := range permissions {
+		responses[i] = p.ResponsePermission(permission)
+	}
+	return responses
+}

--- a/src/presenter/permissions.go
+++ b/src/presenter/permissions.go
@@ -22,8 +22,8 @@ func (p *permissionPresenter) ResponsePermission(permission *models.UserPermissi
 		UserID:     permission.UserID.String(),
 		Permission: permission.Permission,
 		Resource:   permission.Resource,
-		CreatedAt:  permission.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt:  permission.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:  permission.CreatedAt.Format(ISO8601Format),
+		UpdatedAt:  permission.UpdatedAt.Format(ISO8601Format),
 	}
 }
 

--- a/src/presenter/versions.go
+++ b/src/presenter/versions.go
@@ -1,0 +1,37 @@
+package presenter
+
+import (
+	"w3st/domain/models"
+	"w3st/dto"
+)
+
+type VersionPresenter interface {
+	ResponseVersion(version *models.ContentVersion) *dto.VersionResponse
+	ResponseVersions(versions []*models.ContentVersion) []*dto.VersionResponse
+}
+
+type versionPresenter struct{}
+
+func NewVersionPresenter() VersionPresenter {
+	return &versionPresenter{}
+}
+
+func (v *versionPresenter) ResponseVersion(version *models.ContentVersion) *dto.VersionResponse {
+	return &dto.VersionResponse{
+		ID:        version.ID.String(),
+		ContentID: version.ContentID.String(),
+		Version:   version.Version,
+		Data:      string(version.Data),
+		UserID:    version.UserID.String(),
+		CreatedAt: version.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt: version.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+func (v *versionPresenter) ResponseVersions(versions []*models.ContentVersion) []*dto.VersionResponse {
+	responses := make([]*dto.VersionResponse, len(versions))
+	for i, version := range versions {
+		responses[i] = v.ResponseVersion(version)
+	}
+	return responses
+}

--- a/src/presenter/versions.go
+++ b/src/presenter/versions.go
@@ -1,6 +1,8 @@
 package presenter
 
 import (
+	"unicode/utf8"
+
 	"w3st/domain/models"
 	"w3st/dto"
 )
@@ -17,14 +19,18 @@ func NewVersionPresenter() VersionPresenter {
 }
 
 func (v *versionPresenter) ResponseVersion(version *models.ContentVersion) *dto.VersionResponse {
+	dataStr := string(version.Data)
+	if !utf8.ValidString(dataStr) {
+		dataStr = "" // Invalid UTF-8, set to empty string
+	}
 	return &dto.VersionResponse{
 		ID:        version.ID.String(),
 		ContentID: version.ContentID.String(),
 		Version:   version.Version,
-		Data:      string(version.Data),
+		Data:      dataStr,
 		UserID:    version.UserID.String(),
-		CreatedAt: version.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt: version.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt: version.CreatedAt.Format(ISO8601Format),
+		UpdatedAt: version.UpdatedAt.Format(ISO8601Format),
 	}
 }
 


### PR DESCRIPTION
## 関連するチケット

- https://w3st-cms-back.atlassian.net/browse/CPG-16

---

## 概要 (Overview)

ユースケースからの出力をクライアントに適したJSON形式に整形するためのプレゼンターを作成しました。これにより、APIレスポンスの統一されたフォーマット化が可能になります。

---

## 変更内容 (Changes)

- [x] **新機能 (New feature)**

具体的な変更内容をリスト形式で記述してください。

- `src/presenter/media.go` の新規作成: MediaAssetモデルをMediaResponse DTOに変換するプレゼンター
- `src/presenter/versions.go` の新規作成: ContentVersionモデルをVersionResponse DTOに変換するプレゼンター
- `src/presenter/permissions.go` の新規作成: UserPermissionモデルをPermissionResponse DTOに変換するプレゼンター
- `src/presenter/audit.go` の新規作成: AuditLogモデルをAuditLogResponse DTOに変換するプレゼンター

各プレゼンターは単一オブジェクトと複数オブジェクトの両方を扱うメソッドを提供し、UUID型を文字列に、time.TimeをISO 8601形式の文字列に変換します。

---

## スクリーンショット (Screenshots)

UIの変更はありません。

---

## 特記事項 (Additional Notes)

既存の `src/presenter/user.go` のパターンを参考に実装しました。コントローラー層での使用を想定しています。