### PR TITLE
[CPG-17]: Factoryインターフェースに新しいコントローラー初期化メソッドを追加

### DIFF
--- a/src/factory/factory.go
+++ b/src/factory/factory.go
@@ -14,6 +14,10 @@ type Factory interface {
 	InitAuthUsecase() usecase.JwtUsecase
 	InitCollectionController() *controllers.CollectionsController
 	InitFieldController() *controllers.FieldController
+	InitMediaController() *controllers.MediaController
+	InitAuditController() *controllers.AuditController
+	InitPermissionController() *controllers.PermissionController
+	InitVersionController() *controllers.VersionController
 }
 
 type factory struct {
@@ -50,4 +54,32 @@ func (f factory) InitFieldController() *controllers.FieldController {
 	fieldUsecase := usecase.NewFieldUsecase(fieldRepo, collectionRepo)
 
 	return controllers.NewFieldController(fieldUsecase)
+}
+
+func (f factory) InitMediaController() *controllers.MediaController {
+	mediaRepo := infrastructure.NewMediaRepositoryImpl(f.DB)
+	mediaUsecase := usecase.NewMediaUsecase(mediaRepo)
+
+	return controllers.NewMediaController(mediaUsecase)
+}
+
+func (f factory) InitAuditController() *controllers.AuditController {
+	auditRepo := infrastructure.NewAuditRepositoryImpl(f.DB)
+	auditUsecase := usecase.NewAuditUsecase(auditRepo)
+
+	return controllers.NewAuditController(auditUsecase)
+}
+
+func (f factory) InitPermissionController() *controllers.PermissionController {
+	permissionRepo := infrastructure.NewPermissionRepositoryImpl(f.DB)
+	permissionUsecase := usecase.NewPermissionUsecase(permissionRepo)
+
+	return controllers.NewPermissionController(permissionUsecase)
+}
+
+func (f factory) InitVersionController() *controllers.VersionController {
+	versionRepo := infrastructure.NewVersionRepositoryImpl(f.DB)
+	versionUsecase := usecase.NewVersionUsecase(versionRepo)
+
+	return controllers.NewVersionController(versionUsecase)
 }


### PR DESCRIPTION
## 関連するチケット

- https://w3st-cms-back.atlassian.net/browse/CPG-17
---

## 概要 (Overview)

新規作成した各層のコンポーネント（Media、Audit、Permissions、Versions）を初期化し、依存関係を解決するためのファクトリ設定を追加しました。これにより、依存性注入（DI）の仕組みが拡張され、新機能の統合が可能になります。

---

## 変更内容 (Changes)

- [x] **リファクタリング (Refactoring)**

具体的な変更内容をリスト形式で記述してください。

- Factory インターフェースに InitMediaController、InitAuditController、InitPermissionController、InitVersionController のメソッドを追加
- factory 構造体に各コントローラーの初期化メソッドを実装（リポジトリとユースケースの依存関係解決を含む）
- 各メソッドは対応するインフラ層のリポジトリ実装とユースケースを初期化してコントローラーを生成

---

## スクリーンショット (Screenshots)

UIの変更がないため、スクリーンショットは不要です。

---

## 特記事項 (Additional Notes)

この変更は #13  の完了を前提としており、新規コンポーネントの各層（domain、usecase、infra、interfaces）が既に実装されていることを想定しています。ビルドテストは成功しており、コンパイルエラーはありません。