### PR TITLE
[CPG-18]: ルーターにメディア、バージョン、権限、監査のルートを追加

### DIFF
--- a/src/router/router.go
+++ b/src/router/router.go
@@ -55,6 +55,18 @@ func Init() {
 	// Fields
 	fieldController := f.InitFieldController()
 
+	// Media
+	mediaController := f.InitMediaController()
+
+	// Versions
+	versionController := f.InitVersionController()
+
+	// Permissions
+	permissionController := f.InitPermissionController()
+
+	// Audit
+	auditController := f.InitAuditController()
+
 	// ユーザー登録
 	users.POST("/signup", userController.Signup)
 
@@ -77,6 +89,34 @@ func Init() {
 	fields.PUT("/:fieldId", middlewares.JwtAuthMiddleware(authUsecase), fieldController.Update)
 	fields.DELETE("/:fieldId", middlewares.JwtAuthMiddleware(authUsecase), fieldController.Delete)
 	collections.GET("/:collectionId", middlewares.JwtAuthMiddleware(authUsecase), collectionController.GetCollectionsByCollectionId)
+
+	// Media routes
+	media := r.Group("/media")
+	media.POST("", middlewares.JwtAuthMiddleware(authUsecase), mediaController.Upload)
+	media.GET("", middlewares.JwtAuthMiddleware(authUsecase), mediaController.GetByUserID)
+	media.GET("/:id", middlewares.JwtAuthMiddleware(authUsecase), mediaController.GetByID)
+	media.DELETE("/:id", middlewares.JwtAuthMiddleware(authUsecase), mediaController.Delete)
+
+	// Versions routes
+	versions := r.Group("/versions")
+	versions.POST("", middlewares.JwtAuthMiddleware(authUsecase), versionController.CreateVersion)
+	versions.GET("/:contentID", middlewares.JwtAuthMiddleware(authUsecase), versionController.GetVersionsByContentID)
+	versions.GET("/:contentID/latest", middlewares.JwtAuthMiddleware(authUsecase), versionController.GetLatestVersion)
+	versions.POST("/:contentID/restore/:versionID", middlewares.JwtAuthMiddleware(authUsecase), versionController.RestoreVersion)
+
+	// Permissions routes
+	permissions := r.Group("/permissions")
+	permissions.GET("/check", middlewares.JwtAuthMiddleware(authUsecase), permissionController.CheckPermission)
+	permissions.POST("/grant", middlewares.JwtAuthMiddleware(authUsecase), permissionController.GrantPermission)
+	permissions.POST("/revoke", middlewares.JwtAuthMiddleware(authUsecase), permissionController.RevokePermission)
+	permissions.GET("", middlewares.JwtAuthMiddleware(authUsecase), permissionController.GetPermissionsByUser)
+
+	// Audit routes
+	audit := r.Group("/audit")
+	audit.POST("", middlewares.JwtAuthMiddleware(authUsecase), auditController.LogAction)
+	audit.GET("", middlewares.JwtAuthMiddleware(authUsecase), auditController.GetLogsByUser)
+	audit.GET("/action/:action", middlewares.JwtAuthMiddleware(authUsecase), auditController.GetLogsByAction)
+	audit.GET("/all", middlewares.JwtAuthMiddleware(authUsecase), auditController.GetAllLogs)
 
 	// 指定されたポートでサーバーを開始
 	if err := r.Run(fmt.Sprintf(":%s", port)); err != nil {


### PR DESCRIPTION
## 関連するチケット

- https://w3st-cms-back.atlassian.net/browse/CPG-18

---

## 概要 (Overview)

新規コントローラーに対応するAPIエンドポイントをルーターに追加します。

---

## 変更内容 (Changes)

- [x] **新機能 (New feature)**

具体的な変更内容をリスト形式で記述してください。

- `src/router/router.go` に新規コントローラーの初期化を追加
- `/media/` エンドポイントを追加（アップロード、取得、削除）
- `/versions/` エンドポイントを追加（作成、取得、復元）
- `/permissions/` エンドポイントを追加（チェック、付与、取り消し）
- `/audit/` エンドポイントを追加（ログ記録、取得）
- 各ルートにJWT認証ミドルウェアを適用

---

## スクリーンショット (Screenshots)

UIの変更がある場合は、変更前後のスクリーンショットを添付してください。

コード変更のため、スクリーンショットなし

---

## 特記事項 (Additional Notes)

レビュー担当者に特に伝えておきたいことや、懸念事項などがあれば記述してください。
